### PR TITLE
Fix ConsoleImage style

### DIFF
--- a/client/src/pages/ProjetosPage.js
+++ b/client/src/pages/ProjetosPage.js
@@ -49,7 +49,7 @@ const ConsoleSection = styled.section`
 
 const ConsoleImage = styled.img`
   width: 100%;
-  display: block
+  display: block;
   z-index: 1;
 `;
 


### PR DESCRIPTION
## Summary
- add missing semicolon to `display: block` rule in ConsoleImage component

## Testing
- `npm run lint` *(fails: Unknown command "lint")*
- `npm --prefix client test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866db651d7c8322b5542f4229ff85aa