### PR TITLE
Update App test to check header

### DIFF
--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Home link from header', async () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const homeLink = await screen.findByRole('link', { name: /home/i });
+  expect(homeLink).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update client/src/App.test.js to look for the "Home" link

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866db89af4c83228a740978363b48ae