### PR TITLE
Fix App tests

### DIFF
--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,15 +1,24 @@
 import { render, screen } from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
 import App from './App';
 
 
 test('renders home page heading', async () => {
-  render(<App />);
+  render(
+    <HelmetProvider>
+      <App />
+    </HelmetProvider>
+  );
   const heading = await screen.findByText(/BOAS VINDAS À/i);
   expect(heading).toBeInTheDocument();
+});
 
 test('renders Home link from header', async () => {
-  render(<App />);
-  const homeLink = await screen.findByRole('link', { name: /home/i });
-  expect(homeLink).toBeInTheDocument();
-
+  render(
+    <HelmetProvider>
+      <App />
+    </HelmetProvider>
+  );
+  const homeLinks = await screen.findAllByRole('link', { name: /home/i });
+  expect(homeLinks.length).toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Summary
- add missing HelmetProvider for tests
- close first test properly in App.test.js
- use findAllByRole when multiple 'Home' links exist

## Testing
- `npm test --prefix client -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686800bab17c8322a6e6b4840db7f6f6